### PR TITLE
데이터 prefetch 작업 추가 및 DataStore 연동

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -76,8 +76,9 @@ repositories {
 
 dependencies {
   kapt(libs.android.hilt.compile)
+
+  debugImplementation(libs.android.leakcanary)
   implementations(
-    libs.android.leakcanary,
     libs.android.hilt.runtime,
     libs.androidx.appcompat, // needed for naver-map
     libs.androidx.annotation,
@@ -91,11 +92,17 @@ dependencies {
     libs.bundles.jackson,
     libs.bundles.ktor.client,
   )
+
   testImplementations(
-    libs.test.ktor.client.mock,
     libs.test.kotlinx.coroutines,
-    libs.bundles.kotest,
+    libs.test.ktor.client.mock,
+    libs.test.kotest.framework,
+    libs.test.junit.core,
+    libs.test.androidx.junit.ktx,
+    libs.test.robolectric,
   )
+  testRuntimeOnly(libs.test.junit.engine)
+
   detektPlugins(libs.detekt.plugin.formatting)
 }
 

--- a/app/src/main/kotlin/io/github/jisungbin/covid19center/activity/PrefetchActivity.kt
+++ b/app/src/main/kotlin/io/github/jisungbin/covid19center/activity/PrefetchActivity.kt
@@ -10,13 +10,42 @@ package io.github.jisungbin.covid19center.activity
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.material3.Text
+import androidx.compose.runtime.LaunchedEffect
+import dagger.hilt.android.AndroidEntryPoint
+import io.github.jisungbin.covid19center.datasource.dataStore
+import io.github.jisungbin.covid19center.datasource.removeCovidCenterData
+import io.github.jisungbin.covid19center.datasource.writeCovidCenterData
+import io.github.jisungbin.covid19center.model.domain.CovidCenterItem
+import io.github.jisungbin.covid19center.viewmodel.CovidCenterViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
 
+@AndroidEntryPoint
 class PrefetchActivity : ComponentActivity() {
+
+  @Inject
+  lateinit var vm: CovidCenterViewModel
+
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContent {
-      Text("Hello, World!")
+      LaunchedEffect(Unit) {
+        applicationContext.dataStore.removeCovidCenterData()
+
+        val jobs = ArrayList<Job>(10)
+        val items = ArrayList<CovidCenterItem>(100)
+        repeat(10) { pageIndex ->
+          jobs += launch(Dispatchers.IO) {
+            items += vm.getCenterList(page = pageIndex)
+          }
+        }
+
+        jobs.joinAll()
+        applicationContext.dataStore.writeCovidCenterData(items)
+      }
     }
   }
 }

--- a/app/src/main/kotlin/io/github/jisungbin/covid19center/datasource/DataStore.kt
+++ b/app/src/main/kotlin/io/github/jisungbin/covid19center/datasource/DataStore.kt
@@ -1,0 +1,46 @@
+/*
+ * Designed and developed by Ji Sungbin 2023.
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/jisungbin/Covid19CenterApp/blob/main/LICENSE
+ */
+
+package io.github.jisungbin.covid19center.datasource
+
+import android.content.Context
+import androidx.annotation.VisibleForTesting
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.github.jisungbin.covid19center.datasource.mapper.objectMapper
+import io.github.jisungbin.covid19center.model.domain.CovidCenterItem
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.flow.firstOrNull
+
+private const val CovidCenterDataStoreKey = "CovidItems"
+
+@VisibleForTesting
+val CovidCenterDataStoreItemKey = stringPreferencesKey("CovidCenterDataStoreItem")
+
+val Context.dataStore by preferencesDataStore(name = CovidCenterDataStoreKey)
+
+suspend fun DataStore<Preferences>.removeCovidCenterData() {
+  edit { preference ->
+    preference.remove(CovidCenterDataStoreItemKey)
+  }
+}
+
+suspend fun DataStore<Preferences>.writeCovidCenterData(items: List<CovidCenterItem>) {
+  edit { preference ->
+    preference[CovidCenterDataStoreItemKey] = objectMapper.writeValueAsString(items)
+  }
+}
+
+suspend fun DataStore<Preferences>.readCovidCenterDataAsImmutableListOrNull(): ImmutableList<CovidCenterItem>? {
+  val itemJson = data.firstOrNull()?.get(CovidCenterDataStoreItemKey) ?: return null
+  return objectMapper.readValue<List<CovidCenterItem>>(itemJson).toImmutableList()
+}

--- a/app/src/main/kotlin/io/github/jisungbin/covid19center/datasource/mapper/object.kt
+++ b/app/src/main/kotlin/io/github/jisungbin/covid19center/datasource/mapper/object.kt
@@ -1,0 +1,18 @@
+/*
+ * Designed and developed by Ji Sungbin 2023.
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/jisungbin/Covid19CenterApp/blob/main/LICENSE
+ */
+
+package io.github.jisungbin.covid19center.datasource.mapper
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+
+val objectMapper: ObjectMapper =
+  ObjectMapper()
+    .registerKotlinModule()
+    .disable(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES)
+    .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)

--- a/app/src/main/kotlin/io/github/jisungbin/covid19center/datasource/mapper/response2domain.kt
+++ b/app/src/main/kotlin/io/github/jisungbin/covid19center/datasource/mapper/response2domain.kt
@@ -16,7 +16,6 @@ import java.text.SimpleDateFormat
 import java.util.Locale
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
-import kotlinx.collections.immutable.toImmutableList
 
 fun CovidCenterResponse.toDomain() =
   ensureValid(data).fastMap { item ->
@@ -30,7 +29,7 @@ fun CovidCenterResponse.toDomain() =
       phoneNumber = ensureValid(item.phoneNumber),
       updatedAt = ensureValid(item.updatedAt).toDate(),
     )
-  }.toImmutableList()
+  }
 
 private fun <T> ensureValid(data: T?): T {
   contract { returns() implies (data != null) }

--- a/app/src/main/kotlin/io/github/jisungbin/covid19center/viewmodel/CovidCenterViewModel.kt
+++ b/app/src/main/kotlin/io/github/jisungbin/covid19center/viewmodel/CovidCenterViewModel.kt
@@ -7,12 +7,10 @@
 
 package io.github.jisungbin.covid19center.viewmodel
 
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import io.github.jisungbin.covid19center.datasource.exception.CovidCenterServerException
 import io.github.jisungbin.covid19center.datasource.exception.CovidCenterUnauthorizedException
+import io.github.jisungbin.covid19center.datasource.mapper.objectMapper
 import io.github.jisungbin.covid19center.datasource.mapper.toDomain
 import io.github.jisungbin.covid19center.model.data.CovidCenterResponse
 import io.github.jisungbin.covid19center.model.domain.CovidCenterItem
@@ -22,23 +20,13 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.http.parameters
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlinx.collections.immutable.ImmutableList
-
-private val objectMapper =
-  ObjectMapper()
-    .registerKotlinModule()
-    .disable(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES)
-    .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
 
 @Singleton
 class CovidCenterViewModel @Inject constructor(
   private val covidCenterHttpClient: HttpClient,
 ) {
   @Throws(CovidCenterUnauthorizedException::class, CovidCenterServerException::class)
-  suspend fun getCenterList(
-    page: Int,
-    perPage: Int = 10,
-  ): ImmutableList<CovidCenterItem> {
+  suspend fun getCenterList(page: Int, perPage: Int = 10): List<CovidCenterItem> {
     val httpResponse = covidCenterHttpClient.get {
       parameters {
         append("page", "$page")

--- a/app/src/test/kotlin/io/github/jisungbin/covid19center/DataStoreTest.kt
+++ b/app/src/test/kotlin/io/github/jisungbin/covid19center/DataStoreTest.kt
@@ -1,0 +1,85 @@
+/*
+ * Designed and developed by Ji Sungbin 2023.
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/jisungbin/Covid19CenterApp/blob/main/LICENSE
+ */
+
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package io.github.jisungbin.covid19center
+
+import android.content.Context
+import androidx.datastore.preferences.core.MutablePreferences
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.preferencesDataStoreFile
+import androidx.test.core.app.ApplicationProvider
+import io.github.jisungbin.covid19center.datasource.CovidCenterDataStoreItemKey
+import io.github.jisungbin.covid19center.datasource.DummyResponse
+import io.github.jisungbin.covid19center.datasource.readCovidCenterDataAsImmutableListOrNull
+import io.github.jisungbin.covid19center.datasource.writeCovidCenterData
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class DataStoreTest {
+  private val context = ApplicationProvider.getApplicationContext<Context>()
+
+  private val testCoroutineDispatcher = StandardTestDispatcher()
+  private val testCoroutineScope = TestScope(testCoroutineDispatcher + Job())
+
+  private val testDataStoreFileName = "CovidCenterDataTestData"
+  private val testDataStore =
+    PreferenceDataStoreFactory.create(
+      scope = testCoroutineScope,
+      produceFile = { context.preferencesDataStoreFile(testDataStoreFileName) },
+    )
+
+  @Before
+  fun setUp() {
+    Dispatchers.setMain(testCoroutineDispatcher)
+  }
+
+  @Test
+  fun writeCovidCenterData_NoException() = runTest {
+    testDataStore.writeCovidCenterData(DummyResponse.CenterItemList)
+
+    /* ktlint-disable max-line-length */
+    val actualWritedJson =
+      "[{\"id\":1,\"centerType\":\"청춘의\",\"address\":\"그들의 인간은 타오르고 할지라도 아니더면\",\"centerName\":\"사막이다.\",\"facilityName\":\"들은 바이며, 철환하였는가?\",\"phoneNumber\":\"02-1234-1234\",\"updatedAt\":1626378909000},{\"id\":2,\"centerType\":\"용기가\",\"address\":\"이상은 얼마나 커다란 충분히\",\"centerName\":\"이상의 물방아 있는가\",\"facilityName\":\"그와 꽃 청춘\",\"phoneNumber\":\"051-444-1111\",\"updatedAt\":1673506381000},{\"id\":3,\"centerType\":\"현저하게\",\"address\":\"할지라도 그것을 든 생의 그들을\",\"centerName\":\"들어 오아이스도 힘차게\",\"facilityName\":\"가장 창공에 황금시대다\",\"phoneNumber\":\"032-111-0000\",\"updatedAt\":1575030081000}]"
+    /* ktlint-enable max-line-length */
+
+    testDataStore.data.first()[CovidCenterDataStoreItemKey] shouldBe actualWritedJson
+  }
+
+  @Test
+  fun readCovidCenterDataAsImmutableListOrNull_SuccessAndNotNull() = runTest {
+    testDataStore.writeCovidCenterData(DummyResponse.CenterItemList)
+    val result = testDataStore.readCovidCenterDataAsImmutableListOrNull()
+
+    result shouldContainExactly DummyResponse.CenterItemList
+  }
+
+  @After
+  fun tearDown() {
+    Dispatchers.resetMain()
+    testCoroutineScope.runTest { testDataStore.edit(MutablePreferences::clear) }
+    testCoroutineScope.cancel()
+  }
+}

--- a/app/src/test/kotlin/io/github/jisungbin/covid19center/datasource/DummyResponse.kt
+++ b/app/src/test/kotlin/io/github/jisungbin/covid19center/datasource/DummyResponse.kt
@@ -11,8 +11,6 @@ package io.github.jisungbin.covid19center.datasource
 
 import io.github.jisungbin.covid19center.model.domain.CovidCenterItem
 import io.github.jisungbin.covid19center.util.buildDate
-import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.persistentListOf
 import org.intellij.lang.annotations.Language
 
 object DummyResponse {
@@ -77,7 +75,7 @@ object DummyResponse {
 }
 """
 
-  val CenterItemList: ImmutableList<CovidCenterItem> = persistentListOf(
+  val CenterItemList = listOf(
     CovidCenterItem(
       id = 1,
       centerType = "청춘의",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,10 @@ ktor-client-core = "2.3.0"
 jackson-core = "2.14.2"
 
 test-kotest = "5.6.2"
+test-junit-core = "4.13.2"
+test-junit-engine = "5.9.3"
+test-androidx-junit-ktx = "1.1.5"
+test-robolectric = "4.10.3"
 
 [plugins]
 gradle-dependency-handler-extensions = { id = "land.sungbin.dependency.handler.extensions", version.ref = "gradle-dependency-handler-extensions" }
@@ -56,7 +60,7 @@ android-hilt-runtime = { module = "com.google.dagger:hilt-android", version.ref 
 android-hilt-compile = { module = "com.google.dagger:hilt-android-compiler", version.ref = "android-hilt" }
 
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
-androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "androidx-annotation" } # needed for screenshot-matcher
+androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "androidx-annotation" }
 androidx-datastore = { module = "androidx.datastore:datastore-preferences", version.ref = "androidx-datastore" }
 
 # This isn't strictly used but allows Renovate to see us using the compose-compiler artifact
@@ -80,10 +84,13 @@ ktor-client-serialization-jackson = { module = "io.ktor:ktor-serialization-jacks
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson-core" }
 jackson-annotation = { module = "com.fasterxml.jackson.core:jackson-annotations", version.ref = "jackson-core" }
 
-test-ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor-client-core" }
 test-kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
+test-ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor-client-core" }
 test-kotest-framework = { module = "io.kotest:kotest-runner-junit5-jvm", version.ref = "test-kotest" }
-test-kotest-assertion-core = { module = "io.kotest:kotest-assertions-core-jvm", version.ref = "test-kotest" }
+test-junit-core = { module = "junit:junit", version.ref = "test-junit-core" }
+test-junit-engine = { module = "org.junit.vintage:junit-vintage-engine", version.ref = "test-junit-engine" } # testRuntimeOnly
+test-androidx-junit-ktx = { module = "androidx.test.ext:junit-ktx", version.ref = "test-androidx-junit-ktx" }
+test-robolectric = { module = "org.robolectric:robolectric", version.ref = "test-robolectric" }
 
 detekt-plugin-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "kotlin-detekt" }
 
@@ -91,4 +98,3 @@ detekt-plugin-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-format
 compose = ["compose-runtime", "compose-foundation", "compose-ui", "compose-animation", "compose-material3"]
 jackson = ["jackson-databind", "jackson-annotation"]
 ktor-client = ["ktor-client-core", "ktor-client-logging", "ktor-client-engine-cio", "ktor-client-content-negotiation", "ktor-client-serialization-jackson"]
-kotest = ["test-kotest-framework", "test-kotest-assertion-core"]


### PR DESCRIPTION
## Overview

- `HttpClient`를 통한 데이터 반환 타입 `List`로 변경
- `PrefetchActivity`에 데이터 prefetch 작업 추가
- DataStore 작업 추가